### PR TITLE
Exclude offers that I'm already in a trade with

### DIFF
--- a/migrations/create-trade.txt
+++ b/migrations/create-trade.txt
@@ -4,9 +4,9 @@ Depends: create-offer
 Apply: |
   CREATE TABLE "trade" (
     "id" SERIAL8 PRIMARY KEY UNIQUE,
-    "offer1_id" INT8 REFERENCES "offer" NOT NULL,
-    "offer2_id" INT8 REFERENCES "offer" NOT NULL,
-    "is_open" BOOL NOT NULL,
+    "accepted_offer_id" INT8 REFERENCES "offer" NOT NULL,
+    "exchange_offer_id" INT8 REFERENCES "offer" NOT NULL,
+    "is_mutual" BOOL NOT NULL,
     "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
   );

--- a/src/Models/Trade.hs
+++ b/src/Models/Trade.hs
@@ -17,9 +17,9 @@ TH.share
     [TH.mkPersist TH.sqlSettings, TH.mkMigrate "migrateAll"]
     [TH.persistLowerCase|
     Trade json
-        offer1Id OfferId
-        offer2Id OfferId
-        isOpen Bool
+        acceptedOfferId OfferId
+        exchangeOfferId OfferId
+        isMutual Bool
         createdAt UTCTime default=CURRENT_TIMESTAMP
         updatedAt UTCTime default=CURRENT_TIMESTAMP
 |]
@@ -28,7 +28,7 @@ instance Eq Trade where
     trade1 == trade2 =
         all
             id
-            [ tradeOffer1Id trade1 == tradeOffer1Id trade2
-            , tradeOffer2Id trade1 == tradeOffer2Id trade2
-            , tradeIsOpen trade1 == tradeIsOpen trade2
+            [ tradeAcceptedOfferId trade1 == tradeAcceptedOfferId trade2
+            , tradeExchangeOfferId trade1 == tradeExchangeOfferId trade2
+            , tradeIsMutual trade1 == tradeIsMutual trade2
             ]

--- a/src/Queries/Trade.hs
+++ b/src/Queries/Trade.hs
@@ -16,9 +16,18 @@ findFromOffers offer1Key offer2Key = sHead <$> foundTrades
         select $
         from $ \trades -> do
             where_
-                ((trades ^. TradeOffer1Id ==. val offer1Key) ||.
-                 (trades ^. TradeOffer2Id ==. val offer1Key))
+                ((trades ^. TradeAcceptedOfferId ==. val offer1Key) ||.
+                 (trades ^. TradeExchangeOfferId ==. val offer1Key))
             where_
-                ((trades ^. TradeOffer1Id ==. val offer2Key) ||.
-                 (trades ^. TradeOffer2Id ==. val offer2Key))
+                ((trades ^. TradeAcceptedOfferId ==. val offer2Key) ||.
+                 (trades ^. TradeExchangeOfferId ==. val offer2Key))
             return trades
+
+findAccepted :: Pg.Key Offer -> App [Pg.Entity Trade]
+findAccepted offerKey =
+    Db.run $
+    select $
+    from $ \(trades `InnerJoin` offers) -> do
+        on (trades ^. TradeAcceptedOfferId ==. offers ^. OfferId)
+        where_ (trades ^. TradeAcceptedOfferId ==. val offerKey)
+        return trades

--- a/test/Queries/MatchSpec.hs
+++ b/test/Queries/MatchSpec.hs
@@ -101,6 +101,7 @@ spec =
                   offers <- findMatches currUser
                   return ((offerDescription . Sql.entityVal) <$> offers)
               matchDescriptions `shouldBe` ["i sand fence", "i've sanded once"]
+              length matchDescriptions `shouldBe` 2
             it "can find a user's matching offers by offer" $ \config -> do
               matchDescriptions <- runAppToIO config $ do
                   currUser <- complexDbSetup

--- a/test/Queries/TradeSpec.hs
+++ b/test/Queries/TradeSpec.hs
@@ -32,7 +32,7 @@ defaultUser time =
 spec :: Spec
 spec =
   around setupTeardown $
-    describe "Queries.Trade" $
+    describe "Queries.Trade" $ do
       it "findFromOffers" $ \config -> do
         (foundTradeKey, existingTradeKey) <- runAppToIO config $ do
           time <- liftIO getCurrentTime
@@ -45,3 +45,19 @@ spec =
           foundTrade <- findFromOffers offer2Key offer1Key
           return (Pg.entityKey <$> foundTrade, tradeKey)
         foundTradeKey `shouldBe` Just existingTradeKey
+      it "findAccepted" $ \config -> do
+        (foundTrades, expectedTrades) <- runAppToIO config $ do
+          time <- liftIO getCurrentTime
+          photoKey <- Db.run $ Pg.insert (Photo Nothing "cat.png" time time)
+          categoryKey <- Db.run $ Pg.insert (Category "tutor" time time)
+          userKey <- Db.run $ Pg.insert (defaultUser time)
+          acceptedOfferKey <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "physics" 1 time time)
+          exchangeOffer1Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "calculus" 1 time time)
+          exchangeOffer2Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "chem" 1 time time)
+          exchangeOffer3Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "biology" 1 time time)
+          trade1Key <- Db.run $ Pg.insert (Trade acceptedOfferKey exchangeOffer1Key True time time)
+          trade2Key <- Db.run $ Pg.insert (Trade exchangeOffer3Key exchangeOffer2Key True time time)
+          trade3Key <- Db.run $ Pg.insert (Trade acceptedOfferKey exchangeOffer3Key True time time)
+          foundTrades <- findAccepted acceptedOfferKey
+          return (Pg.entityKey <$> foundTrades, [trade1Key, trade3Key])
+        foundTrades `shouldBe` expectedTrades


### PR DESCRIPTION
- change Trade model so that offer1Id is now acceptedOfferId, offer2Id is now exchangeOfferId, and isOpen is now isMutual

- findAccepted function in Queries.Trade to find all trades where given offer is accepted offer
- hasAcceptedOffer function in Api.Match to take offer and list of offers and tells where given offer has been accepted with trade where any other offers are involved
- getMatches function in Api.Match to exclude offers that have already been accepted in exchange for user offer