### PR TITLE
RESTify Api.Trade

### DIFF
--- a/migrations/create-trade.txt
+++ b/migrations/create-trade.txt
@@ -6,9 +6,10 @@ Apply: |
     "id" SERIAL8 PRIMARY KEY UNIQUE,
     "accepted_offer_id" INT8 REFERENCES "offer" NOT NULL,
     "exchange_offer_id" INT8 REFERENCES "offer" NOT NULL,
-    "is_mutual" BOOL NOT NULL,
+    "is_mutual" BOOL NOT NULL DEFAULT FALSE,
     "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+    "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE ("accepted_offer_id", "exchange_offer_id")
   );
 Revert: |
   DROP TABLE "trade";

--- a/src/Models/Trade.hs
+++ b/src/Models/Trade.hs
@@ -19,9 +19,11 @@ TH.share
     Trade json
         acceptedOfferId OfferId
         exchangeOfferId OfferId
-        isMutual Bool
+        isMutual Bool default=FALSE
         createdAt UTCTime default=CURRENT_TIMESTAMP
         updatedAt UTCTime default=CURRENT_TIMESTAMP
+        TradeOfferIds acceptedOfferId exchangeOfferId
+        deriving Show
 |]
 
 instance Eq Trade where

--- a/test/Api/TradeSpec.hs
+++ b/test/Api/TradeSpec.hs
@@ -38,41 +38,7 @@ spec =
       it "createTrade" $ \config ->
         let
           tradeReq offer1Key offer2Key =
-            TradeRequest
-              { acceptedOfferId = Pg.fromSqlKey offer1Key
-              , exchangeOfferId = Pg.fromSqlKey offer2Key
-              }
-        in do
-        tradeCount <- runAppToIO config $ do
-          time <- liftIO getCurrentTime
-          photoKey <- Db.run $ Pg.insert (Photo Nothing "cat.png" time time)
-          categoryKey <- Db.run $ Pg.insert (Category "tutor" time time)
-          userKey <- Db.run $ Pg.insert (defaultUser time)
-          offer1Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "physics" 1 time time)
-          offer2Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "chem" 1 time time)
-          _ <- createTrade (tradeReq offer1Key offer2Key)
-          Db.run $ Pg.count ([] :: [Pg.Filter Trade])
-        tradeCount `shouldBe` 1
-      it "makeMutual" $ \config -> do
-        mbTrade <- runAppToIO config $ do
-          time <- liftIO getCurrentTime
-          photoKey <- Db.run $ Pg.insert (Photo Nothing "cat.png" time time)
-          categoryKey <- Db.run $ Pg.insert (Category "tutor" time time)
-          userKey <- Db.run $ Pg.insert (defaultUser time)
-          offer1Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "physics" 1 time time)
-          offer2Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "chem" 1 time time)
-          tradeKey <- Db.run $ Pg.insert (Trade offer1Key offer2Key True time time)
-          _ <- makeMutual (Pg.fromSqlKey tradeKey)
-          Db.run (Pg.get tradeKey)
-        (tradeIsMutual <$> mbTrade) `shouldBe` Just False
-      context "closeOrCreate" $ do
-        it "creates a trade if one does not already exist" $ \config ->
-          let
-            tradeReq offer1Key offer2Key =
-              TradeRequest
-                { acceptedOfferId = Pg.fromSqlKey offer1Key
-                , exchangeOfferId = Pg.fromSqlKey offer2Key
-                }
+            TradeRequest (Pg.fromSqlKey offer1Key) (Pg.fromSqlKey offer2Key)
           in do
           tradeCount <- runAppToIO config $ do
             time <- liftIO getCurrentTime
@@ -81,28 +47,122 @@ spec =
             userKey <- Db.run $ Pg.insert (defaultUser time)
             offer1Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "physics" 1 time time)
             offer2Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "chem" 1 time time)
-            _ <- closeOrCreate (tradeReq offer1Key offer2Key)
+            _ <- createTrade (tradeReq offer1Key offer2Key)
             Db.run $ Pg.count ([] :: [Pg.Filter Trade])
           tradeCount `shouldBe` 1
-        it "closes the trade if one already exists with given offers" $ \config ->
-          let
-            tradeReq offer1Key offer2Key =
-              TradeRequest
-                { acceptedOfferId = Pg.fromSqlKey offer1Key
-                , exchangeOfferId = Pg.fromSqlKey offer2Key
-                }
-          in do
-          (trade, tradeCount) <- runAppToIO config $ do
-            time <- liftIO getCurrentTime
-            photoKey <- Db.run $ Pg.insert (Photo Nothing "cat.png" time time)
-            categoryKey <- Db.run $ Pg.insert (Category "tutor" time time)
-            userKey <- Db.run $ Pg.insert (defaultUser time)
-            offer1Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "physics" 1 time time)
-            offer2Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "chem" 1 time time)
-            tradeKey <- Db.run $ Pg.insert (Trade offer1Key offer2Key True time time)
-            _ <- closeOrCreate (tradeReq offer1Key offer2Key)
-            mbTrade <- Db.run $ Pg.get tradeKey
-            tradeCount <- Db.run $ Pg.count ([] :: [Pg.Filter Trade])
-            return (mbTrade, tradeCount)
-          (tradeIsMutual <$> trade) `shouldBe` Just False
-          tradeCount `shouldBe` 1
+      context "getTrade" $ do
+        it "takes both offer ids and gets trade" $ \config -> do
+            (trade, offer1Key, offer2Key) <- runAppToIO config $ do
+              time <- liftIO getCurrentTime
+              photoKey <- Db.run $ Pg.insert (Photo Nothing "cat.png" time time)
+              categoryKey <- Db.run $ Pg.insert (Category "tutor" time time)
+              userKey <- Db.run $ Pg.insert (defaultUser time)
+              offer1Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "physics" 1 time time)
+              offer2Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "chem" 1 time time)
+              targetTrade <- Db.run $ Pg.insert
+                                    Trade
+                                      { tradeIsMutual = True
+                                      , tradeAcceptedOfferId = offer1Key
+                                      , tradeExchangeOfferId = offer2Key
+                                      , tradeCreatedAt = time
+                                      , tradeUpdatedAt = time
+                                      }
+              otherTrade <- Db.run $ Pg.insert
+                                    Trade
+                                      { tradeIsMutual = True
+                                      , tradeAcceptedOfferId = offer2Key
+                                      , tradeExchangeOfferId = offer1Key
+                                      , tradeCreatedAt = time
+                                      , tradeUpdatedAt = time
+                                      }
+              foundTrade <- getTrade (Just $ Pg.fromSqlKey offer1Key) (Just $ Pg.fromSqlKey offer2Key)
+              return (foundTrade, offer1Key, offer2Key)
+            tradeAcceptedOfferId . Pg.entityVal <$> trade `shouldBe` Just offer1Key
+            tradeExchangeOfferId . Pg.entityVal <$> trade `shouldBe` Just offer2Key
+        it "returns first matching trade if multiple are available" $ \config -> do
+              (trade, offer1Key, offer2Key) <- runAppToIO config $ do
+                time <- liftIO getCurrentTime
+                photoKey <- Db.run $ Pg.insert (Photo Nothing "cat.png" time time)
+                categoryKey <- Db.run $ Pg.insert (Category "tutor" time time)
+                userKey <- Db.run $ Pg.insert (defaultUser time)
+                offer1Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "physics" 1 time time)
+                offer2Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "chem" 1 time time)
+                offer3Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "biology" 1 time time)
+                firstTrade <- Db.run $ Pg.insert
+                                      Trade
+                                        { tradeIsMutual = True
+                                        , tradeAcceptedOfferId = offer1Key
+                                        , tradeExchangeOfferId = offer2Key
+                                        , tradeCreatedAt = time
+                                        , tradeUpdatedAt = time
+                                        }
+                nextTrade <- Db.run $ Pg.insert
+                                      Trade
+                                        { tradeIsMutual = True
+                                        , tradeAcceptedOfferId = offer1Key
+                                        , tradeExchangeOfferId = offer3Key
+                                        , tradeCreatedAt = time
+                                        , tradeUpdatedAt = time
+                                        }
+                foundTrade <- getTrade (Just $ Pg.fromSqlKey offer1Key) Nothing
+                return (foundTrade, offer1Key, offer2Key)
+              tradeAcceptedOfferId . Pg.entityVal <$> trade `shouldBe` Just offer1Key
+              tradeExchangeOfferId . Pg.entityVal <$> trade `shouldBe` Just offer2Key
+        it "returns nothing if no trade is available" $ \config -> do
+              foundTrade <- runAppToIO config (getTrade (Just 1) (Just 2))
+              foundTrade `shouldBe` Nothing
+      context "patchTrade" $ do
+        it "updates multiple fields on trade" $ \config -> do
+            (trade, offer2Key, offer3Key) <- runAppToIO config $ do
+              time <- liftIO getCurrentTime
+              photoKey <- Db.run $ Pg.insert (Photo Nothing "cat.png" time time)
+              categoryKey <- Db.run $ Pg.insert (Category "tutor" time time)
+              userKey <- Db.run $ Pg.insert (defaultUser time)
+              offer1Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "physics" 1 time time)
+              offer2Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "chem" 1 time time)
+              offer3Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "biology" 1 time time)
+              tradeKey <- Db.run $ Pg.insert
+                                    Trade
+                                      { tradeIsMutual = True
+                                      , tradeAcceptedOfferId = offer1Key
+                                      , tradeExchangeOfferId = offer2Key
+                                      , tradeCreatedAt = time
+                                      , tradeUpdatedAt = time
+                                      }
+              _ <- patchTrade (Pg.fromSqlKey tradeKey) $
+                      TradePatchReq
+                        (Just False)
+                        (Just (Pg.fromSqlKey offer2Key))
+                        (Just (Pg.fromSqlKey offer3Key))
+              foundTrade <- Db.run $ Pg.get tradeKey
+              return (foundTrade, offer2Key, offer3Key)
+            tradeAcceptedOfferId <$> trade `shouldBe` Just offer2Key
+            tradeExchangeOfferId <$> trade `shouldBe` Just offer3Key
+            tradeIsMutual <$> trade `shouldBe` Just False
+        it "only updates values that are present on patch request" $ \config -> do
+            (trade, offer1Key, offer3Key) <- runAppToIO config $ do
+              time <- liftIO getCurrentTime
+              photoKey <- Db.run $ Pg.insert (Photo Nothing "cat.png" time time)
+              categoryKey <- Db.run $ Pg.insert (Category "tutor" time time)
+              userKey <- Db.run $ Pg.insert (defaultUser time)
+              offer1Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "physics" 1 time time)
+              offer2Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "chem" 1 time time)
+              offer3Key <- Db.run $ Pg.insert (Offer userKey categoryKey photoKey "biology" 1 time time)
+              tradeKey <- Db.run $ Pg.insert
+                                    Trade
+                                      { tradeIsMutual = True
+                                      , tradeAcceptedOfferId = offer1Key
+                                      , tradeExchangeOfferId = offer2Key
+                                      , tradeCreatedAt = time
+                                      , tradeUpdatedAt = time
+                                      }
+              _ <- patchTrade (Pg.fromSqlKey tradeKey) $
+                      TradePatchReq
+                        (Just False)
+                        Nothing
+                        (Just (Pg.fromSqlKey offer3Key))
+              foundTrade <- Db.run $ Pg.get tradeKey
+              return (foundTrade, offer1Key, offer3Key)
+            tradeAcceptedOfferId <$> trade `shouldBe` Just offer1Key
+            tradeExchangeOfferId <$> trade `shouldBe` Just offer3Key
+            tradeIsMutual <$> trade `shouldBe` Just False


### PR DESCRIPTION
- adjust endpoints for Api.Trade to remove findOrCreate functionality for Api.Trade

- getTrade function to take 2 maybe ints and retrieve existing trade
- remove makeMutual for patchTrade that can update multiple fields on Trade at once.